### PR TITLE
Fix typing to allow different return values per query

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -38,11 +38,11 @@ declare module 'athena-express' {
 
     type OptionalQueryResultsInterface<T> = Partial<QueryResultsInterface<T>> & Pick<QueryResultsInterface<T>, 'QueryExecutionId'>;
     type QueryResult<T> = OptionalQueryResultsInterface<T>;
-    type QueryFunc<T> = (query: QueryObjectInterface|DirectQueryString|QueryExecutionId) => Promise<QueryResult<T>>;
+    type QueryFunc = <T = any>(query: QueryObjectInterface|DirectQueryString|QueryExecutionId) => Promise<QueryResult<T>>;
 
-    class AthenaExpress<T> {
+    class AthenaExpress {
         public new: (config: Partial<ConnectionConfigInterface>) => any;
-        public query: QueryFunc<T>;
+        public query: QueryFunc;
         constructor(config: Partial<ConnectionConfigInterface>);
     }
 }


### PR DESCRIPTION
The current typing requires one to define the return type for all queries when initializing AthenaExpress.

As one wants to execute different queries with different return types they would have to create new instances of AthenaExpress or ignore the typing (using `as` or `@ts-ignore`).

By moving the generic parameter from the class to the `query` method, the expected return type can be set for every call seperatly.

I also added a default parameter `any` so one does not need to define the return type if they do not with to do so or do not know the exact typing, while still being able to use the general typing of `QueryResult`.

This change would require all existing typescript users to update their usage. It would be possible for me to add this in a backwards compatible way if requested.

Example in code:

```typescript
// Type Definitions to illustrate changes
type Movie = {
  name: string;
  year: number;
}

type Song = {
  title: string;
  artist: string;
}


//
// Current behaviour
//
const athenaExpress = new AthenaExpress<Movie>({ /* ... */ });

const movies = await athenaExpress.query("SELECT * FROM movies LIMIT 3");
// Typing of movies.Items is `Movie[]`

// Using different typing for other query is not possible (without type-casting)
const songs = await athenaExpress.query("SELECT * FROM songs LIMIT 3");
// Typing of songs.Items is still `Movie[]

// Updated behaviour
// With my changes it now looks like this:
//
const athenaExpress = new AthenaExpress({ /* ... */ });

const movies = await athenaExpress.query<Movie>("SELECT * FROM movies LIMIT 3");
// Typing of movies.Items is `Movie[]`

const songs = await athenaExpress.query<Song>("SELECT * FROM songs LIMIT 3");
// Typing of songs.Items is `Song[]`

// And if the return type is unknown, one can just omit the typing:
const result = await athenaExpress.query("SELECT * FROM unknownTable LIMIT 3");
// Typing of result.Items is `any[]` 
```